### PR TITLE
fix: PDF download

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Download all your Stripe PDF invoices",
     "type": "project",
     "require": {
+        "ext-curl": "*",
         "stripe/stripe-php": "^7.67"
     },
     "license": "AGPL",

--- a/download.php
+++ b/download.php
@@ -27,7 +27,15 @@ foreach ($invoices->autoPagingIterator() as $invoice) {
     }
 
     echo sprintf("Downloading %s..." . PHP_EOL, $invoice->invoice_pdf);
-    file_put_contents($path, file_get_contents($invoice->invoice_pdf));
+    $fp = fopen($path, 'w');
+
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $invoice->invoice_pdf);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_FILE, $fp);
+
+    curl_exec($ch);
+    fclose($fp);
 }
 
 echo "Done!" . PHP_EOL;


### PR DESCRIPTION
Stripe now redirects to S3 to download the invoice PDF. `file_get_contents()` doesn't handle the redirection properly, while cURL does. cURL is already a hard dependency of the Stripe SDK anyway. This change should also reduce memory usage.