### PR TITLE
Added functionality for "starting_after" or "end_before" to not re-fetch existing invoices

### DIFF
--- a/download.php
+++ b/download.php
@@ -22,12 +22,12 @@ switch ($option) {
     $invoices = $stripe->invoices->all(['limit' => 100]);
     break;
   case "2":
-    $a = readline('Enter an invoice ID. Only invoices after this one will be retrieved: ');
-    $invoices = $stripe->invoices->all(['limit' => 100, 'starting_after' => $a]);
+    $invoice_index = readline('Enter an invoice ID. Only invoices after this one will be retrieved: ');
+    $invoices = $stripe->invoices->all(['limit' => 100, 'starting_after' => $invoice_index]);
     break;
   case "3":
-    $a = readline('Enter an invoice ID. Only invoices before this one will be retrieved: ');
-    $invoices = $stripe->invoices->all(['limit' => 100, 'ending_before' => $a]);
+    $invoice_index = readline('Enter an invoice ID. Only invoices before this one will be retrieved: ');
+    $invoices = $stripe->invoices->all(['limit' => 100, 'ending_before' => $invoice_index]);
     break;
 }
 

--- a/download.php
+++ b/download.php
@@ -13,8 +13,24 @@ if (!isset($_SERVER['STRIPE_KEY'])) {
 
 $stripe = new StripeClient($_SERVER['STRIPE_KEY']);
 
-// TODO: use "starting_after" or "end_before" to not re-fetch existing invoices
-$invoices = $stripe->invoices->all(['limit' => 100]);
+do {
+  $option = readline('Select 1 if you would like to download all invoices. Select 2 if you would like to download all invoices STARTING AFTER a given invoice. Select 3 if you would like to download all invoices BEFORE a given invoice: ');
+} while ($option !== '1' && $option !== '2' && $option !== '3' );
+
+switch ($option) {
+  case "1":
+    $invoices = $stripe->invoices->all(['limit' => 100]);
+    break;
+  case "2":
+    $a = readline('Enter an invoice ID. Only invoices after this one will be retrieved: ');
+    $invoices = $stripe->invoices->all(['limit' => 100, 'starting_after' => $a]);
+    break;
+  case "3":
+    $a = readline('Enter an invoice ID. Only invoices before this one will be retrieved: ');
+    $invoices = $stripe->invoices->all(['limit' => 100, 'ending_before' => $a]);
+    break;
+}
+
 foreach ($invoices->autoPagingIterator() as $invoice) {
     /** @var Invoice $invoice */
     if (!$invoice->invoice_pdf) {


### PR DESCRIPTION
Hi Kévin, I have added functionality so that the User may choose whether they want to 1) download all of their invoices 2) download invoices starting after a given invoice or 3) download invoices before a given invoice. It would be great if you could merge this PR, thanks.